### PR TITLE
Handling "rise-cache-folder-unavailable" event from rise-storage [sta…

### DIFF
--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -189,6 +189,10 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
       RiseVision.Video.logEvent( params, true );
     } );
 
+    storage.addEventListener( "rise-cache-folder-unavailable", function() {
+      RiseVision.Video.onFileUnavailable( "Files are downloading" );
+    } );
+
     storage.setAttribute( "fileType", "video" );
     storage.setAttribute( "companyId", data.storage.companyId );
     storage.setAttribute( "displayId", displayId );
@@ -198,7 +202,18 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
     storage.go();
   }
 
+  function retry() {
+    var storage = document.getElementById( "videoStorage" );
+
+    if ( !storage ) {
+      return;
+    }
+
+    storage.go();
+  }
+
   return {
-    "init": init
+    "init": init,
+    "retry": retry
   };
 };

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -204,10 +204,8 @@ RiseVision.Video = ( function( window, gadgets ) {
       return;
     }
 
-    if ( _unavailableFlag ) {
-      if ( _mode === "file" && _storage ) {
-        _storage.retry();
-      }
+    if ( _unavailableFlag && _storage ) {
+      _storage.retry();
 
       return;
     }

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -219,3 +219,40 @@ suite( "rise cache error", function() {
     RiseVision.Video.play.restore();
   } );
 } );
+
+suite( "cache folder unavailable", function() {
+
+  test( "should show folder unavailable message", function() {
+    storage.dispatchEvent( new CustomEvent( "rise-cache-folder-unavailable", {
+      "detail": {
+        "status": 202,
+        "message": "File is downloading"
+      },
+      "bubbles": true
+    } ) );
+
+    assert.equal( document.querySelector( ".message" ).innerHTML, "Files are downloading", "message text" );
+    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+  } );
+
+  test( "should call play function 5 seconds after a folder unavailable", function() {
+    var clock = sinon.useFakeTimers(),
+      spy = sinon.spy( RiseVision.Video, "play" );
+
+    storage.dispatchEvent( new CustomEvent( "rise-cache-folder-unavailable", {
+      "detail": {
+        "status": 202,
+        "message": "File is downloading"
+      },
+      "bubbles": true
+    } ) );
+
+    clock.tick( 4500 );
+    assert( spy.notCalled );
+    clock.tick( 500 );
+    assert( spy.calledOnce );
+
+    clock.restore();
+    RiseVision.Video.play.restore();
+  } );
+} );


### PR DESCRIPTION
…ge-2]

- Listening for "rise-cache-folder-unavailable" event and handling by following same flow as when a single file is unavailable
- Slight difference in message for folder scenario, using "Files are downloading" instead of "File is downloading" to indicate a folder of files
- Added integration tests