### PR TITLE
Fix call to isV2Running

### DIFF
--- a/src/widget/non-storage.js
+++ b/src/widget/non-storage.js
@@ -47,19 +47,20 @@ RiseVision.Video.NonStorage = function( data ) {
             "file_url": response.url
           }, true );
 
-          if ( riseCache.isV2Running() ) {
-            errorMessage = riseCache.getErrorMessage( statusCode );
-          } else {
-            // Show a different message if there is a 404 coming from rise cache
+          riseCache.isV2Running( function showError( isV2 ) {
             if ( error.message ) {
               statusCode = +error.message.substring( error.message.indexOf( ":" ) + 2 );
             }
 
-            errorMessage = utils.getRiseCacheErrorMessage( statusCode );
-          }
+            if ( isV2 ) {
+              errorMessage = riseCache.getErrorMessage( statusCode );
+            // Show a different message if there is a 404 coming from rise cache
+            } else {
+              errorMessage = utils.getRiseCacheErrorMessage( statusCode );
+            }
 
-          // show the error
-          RiseVision.Video.showError( errorMessage );
+            RiseVision.Video.showError( errorMessage );
+          } );
         }
       }
     }, omitCacheBuster );

--- a/src/widget/storage-file.js
+++ b/src/widget/storage-file.js
@@ -106,19 +106,20 @@ RiseVision.Video.StorageFile = function( data, displayId ) {
       // log the error
       RiseVision.Video.logEvent( params, true );
 
-      if ( riseCache.isV2Running() ) {
-        errorMessage = riseCache.getErrorMessage( statusCode );
-      } else {
-        // Show a different message if there is a 404 coming from rise cache
+      riseCache.isV2Running( function showError( isV2 ) {
         if ( e.detail.error.message ) {
           statusCode = +e.detail.error.message.substring( e.detail.error.message.indexOf( ":" ) + 2 );
         }
 
-        errorMessage = utils.getRiseCacheErrorMessage( statusCode );
-      }
+        if ( isV2 ) {
+          errorMessage = riseCache.getErrorMessage( statusCode );
+        // Show a different message if there is a 404 coming from rise cache
+        } else {
+          errorMessage = utils.getRiseCacheErrorMessage( statusCode );
+        }
 
-      // show the error
-      RiseVision.Video.showError( errorMessage );
+        RiseVision.Video.showError( errorMessage );
+      } );
     } );
 
     storage.addEventListener( "rise-cache-not-running", function( e ) {

--- a/src/widget/storage-folder.js
+++ b/src/widget/storage-folder.js
@@ -165,18 +165,20 @@ RiseVision.Video.StorageFolder = function( data, displayId ) {
 
       RiseVision.Video.logEvent( params, true );
 
-      if ( riseCache.isV2Running() ) {
-        errorMessage = riseCache.getErrorMessage( statusCode );
-      } else {
-        // Show a different message if there is a 404 coming from rise cache
+      riseCache.isV2Running( function showError( isV2 ) {
         if ( e.detail.error.message ) {
           statusCode = +e.detail.error.message.substring( e.detail.error.message.indexOf( ":" ) + 2 );
         }
 
-        errorMessage = utils.getRiseCacheErrorMessage( statusCode );
-      }
+        if ( isV2 ) {
+          errorMessage = riseCache.getErrorMessage( statusCode );
+        // Show a different message if there is a 404 coming from rise cache
+        } else {
+          errorMessage = utils.getRiseCacheErrorMessage( statusCode );
+        }
 
-      RiseVision.Video.showError( errorMessage );
+        RiseVision.Video.showError( errorMessage );
+      } );
     } );
 
     storage.addEventListener( "rise-cache-not-running", function( e ) {

--- a/test/integration/js/file.js
+++ b/test/integration/js/file.js
@@ -229,22 +229,40 @@ suite( "Storage Errors", function() {
 
   test( "should handle when a rise cache error occurs", function() {
     params.event = "rise cache error";
-    params.event_details = "The request failed with status code: 500";
 
-    storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 500"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      params.event_details = "The request failed with status code: 502";
+
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 502"
+          }
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledWith( "There was a problem retrieving the file." ),
+        "showError() called with correct message" );
+    } else {
+      params.event_details = "The request failed with status code: 500";
+
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 500"
+          }
+        },
+        "bubbles": true
+      } ) );
+
+      assert( onShowErrorStub.calledWith( "There was a problem retrieving the file from Rise Cache." ),
+        "showError() called with correct message" );
+    }
 
     assert( onLogEventStub.calledOnce, "logEvent() called once" );
     assert( onLogEventStub.calledWith( params, true ), "logEvent() called with correct params" );
     assert( onShowErrorStub.calledOnce, "showError() called once" );
-    assert( onShowErrorStub.calledWith( "There was a problem retrieving the file from Rise Cache." ),
-      "showError() called with correct message" );
   } );
 
 } );

--- a/test/integration/js/messaging-file.js
+++ b/test/integration/js/messaging-file.js
@@ -143,28 +143,56 @@ suite( "storage error", function() {
 
 suite( "rise cache error", function() {
   test( "should show rise cache error message", function() {
-    storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 500"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 502"
+          }
+        },
+        "bubbles": true
+      } ) );
 
-    assert.equal( document.querySelector( ".message" ).innerHTML, "There was a problem retrieving the file from Rise Cache.", "message text" );
-    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+      assert.equal( document.querySelector( ".message" ).innerHTML,
+        "There was a problem retrieving the file.", "message text" );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 500"
+          }
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML,
+        "There was a problem retrieving the file from Rise Cache.", "message text" );
+    }
+
+    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ),
+      "message visibility" );
   } );
 
   test( "should show rise cache error message for 404 status", function() {
-    storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 534"
+          }
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
     assert.equal( document.querySelector( ".message" ).innerHTML, "The file does not exist or cannot be accessed.", "message text" );
     assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );

--- a/test/integration/js/messaging-folder.js
+++ b/test/integration/js/messaging-folder.js
@@ -156,31 +156,61 @@ suite( "storage error", function() {
 
 suite( "rise cache error", function() {
   test( "should show rise cache error message", function() {
-    storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 500"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 502"
+          }
+        },
+        "bubbles": true
+      } ) );
 
-    assert.equal( document.querySelector( ".message" ).innerHTML, "There was a problem retrieving the file from Rise Cache.", "message text" );
-    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+      assert.equal( document.querySelector( ".message" ).innerHTML,
+        "There was a problem retrieving the file.", "message text" );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 500"
+          }
+        },
+        "bubbles": true
+      } ) );
+
+      assert.equal( document.querySelector( ".message" ).innerHTML,
+        "There was a problem retrieving the file from Rise Cache.", "message text" );
+    }
+
+    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ),
+      "message visibility" );
   } );
 
   test( "should show rise cache error message for 404 status", function() {
-    storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
-      "detail": {
-        "error": {
-          "message": "The request failed with status code: 404"
-        }
-      },
-      "bubbles": true
-    } ) );
+    if ( isV2Running ) {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 534"
+          }
+        },
+        "bubbles": true
+      } ) );
+    } else {
+      storage.dispatchEvent( new CustomEvent( "rise-cache-error", {
+        "detail": {
+          "error": {
+            "message": "The request failed with status code: 404"
+          }
+        },
+        "bubbles": true
+      } ) );
+    }
 
-    assert.equal( document.querySelector( ".message" ).innerHTML, "The file does not exist or cannot be accessed.", "message text" );
-    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ), "message visibility" );
+    assert.equal( document.querySelector( ".message" ).innerHTML,
+      "The file does not exist or cannot be accessed.", "message text" );
+    assert.isTrue( ( document.getElementById( "messageContainer" ).style.display === "block" ),
+      "message visibility" );
   } );
 
   test( "should show rise cache error message for 507 status", function() {


### PR DESCRIPTION
`isV2Running` takes a callback function as a parameter. The function call was missing this callback.

Also, if RC v2 was running, `statusCode` was 0, which would result in no error message showing on the Display. `statusCode` is now set regardless of which version of Rise Cache is running.