### PR TITLE
Retry RC for 3rd party file [stage-2]

### DIFF
--- a/src/widget/non-storage.js
+++ b/src/widget/non-storage.js
@@ -86,7 +86,12 @@ RiseVision.Video.NonStorage = function( data ) {
     _getFile( true );
   }
 
+  function retry() {
+    _getFile( false );
+  }
+
   return {
-    "init": init
+    "init": init,
+    "retry": retry
   };
 };

--- a/src/widget/video.js
+++ b/src/widget/video.js
@@ -204,8 +204,12 @@ RiseVision.Video = ( function( window, gadgets ) {
       return;
     }
 
-    if ( _unavailableFlag && _storage ) {
-      _storage.retry();
+    if ( _unavailableFlag ) {
+      if ( _storage ) {
+        _storage.retry();
+      } else if ( _nonStorage ) {
+        _nonStorage.retry();
+      }
 
       return;
     }

--- a/test/integration/non-storage/messaging.html
+++ b/test/integration/non-storage/messaging.html
@@ -220,6 +220,31 @@
         assert.equal(document.querySelector(".message").innerHTML, "File is downloading", "file is downloading message text");
         assert.isTrue((document.getElementById("messageContainer").style.display === "block"), "message visibility");
       });
+
+      test( "should not show File is downloading message when retry RC and response is 200", function() {
+        var spy = sinon.spy(RiseVision.Video, "play");
+
+        requests[1].respond(202); // HEAD request
+        clock.tick(3000);
+        requests[2].respond(202); // HEAD request
+        clock.tick(3000);
+        requests[3].respond(202); // HEAD request
+        assert.equal(document.querySelector(".message").innerHTML, "File is downloading", "file is downloading message text");
+        assert.isTrue((document.getElementById("messageContainer").style.display === "block"), "message visibility");
+
+        // bypass error timer
+        clock.tick(5000);
+
+        // error flags are set so play() call won't execute non-storage retry(), force it instead
+        nonStorage.retry();
+        requests[4].respond(200);
+
+        assert.isTrue((document.getElementById("container").style.display === "block"), "video container is showing");
+        assert.isTrue((document.getElementById("messageContainer").style.display === "none"), "message container is hidden");
+        assert.isTrue(spy.calledOnce);
+
+        spy.restore();
+      } );
     });
   });
 </script>


### PR DESCRIPTION
- When unavailable flag is set and widget is told to play, now it retries RC for the file
- Integration test added